### PR TITLE
Fix(#8): Fixed ForeignKey Field value evaluation

### DIFF
--- a/docs/assets/docs/foreignKeys.md
+++ b/docs/assets/docs/foreignKeys.md
@@ -1,3 +1,61 @@
 # Foreign Keys
 
-not ready yet
+You can use the ForeginKeyField component to create a field that automatically knows 
+how to pull information of the given metadata of the foreign key.
+
+You can use it inside your templates like this:
+
+```html
+<ngcrudui-foreign-key [formGroup]="formGroup" [config]="fieldConfig" ></ngcrudui-foreign-key>
+```
+
+There are more configuration that you can pass to it,
+let's talk more about that:
+
+The configuration should implement the `FieldConfig` interface with the `control` field to implement the 
+`ForeignKeyControlConfig` interface:
+
+```typescript
+export interface ForeignKeyControlConfig extends ControlConfig {
+    metadata: Metadata;
+    viewConfig?: ViewConfig;
+}
+```
+
+so let's take alook on an example for defining a ForeignKey Field:
+
+```typescript
+{
+    name: 'store',
+    label: 'Outlet',
+    type: 'foreignKey',
+    resolveValueFrom: 'store_id',
+    control: {
+        metadata: new StoreMetadata(),
+        viewConfig: new StoreListView(),
+    }
+}
+```
+
+As you cane see there is a `resolveValueFrom` that would tell NgCrudUi to get/set the value to another field -if you need to, and in the case there has to be a definition for another field, the `store_id` field, but we don't want it to be displayed in the forms, so we can set `isHidden` to true, here is the full example:
+
+```typescript
+{
+    name: 'store_id',
+    label: 'Outlet ID',
+    type: 'number',
+    isHidden: true,
+},
+{
+    name: 'store',
+    label: 'Outlet',
+    type: 'foreignKey',
+    resolveValueFrom: 'store_id',
+    control: {
+        metadata: new StoreMetadata(),
+        viewConfig: new StoreListView(),
+    },
+    isEditable: true,
+    isSearchable: true,
+}
+```

--- a/json-mock/db.json
+++ b/json-mock/db.json
@@ -1,35 +1,34 @@
 {
-    "terminals": [
-        {
-            "id": 1,
-            "number": 1,
-            "description": "Terminal 1",
-            "store_id": 1,
-            "rcrs_number": "1234",
-            "last_invoice_id": 1,
-            "is_locked": false
-        }
-    ],
-    "stores": [
-        {
-            "id": 1,
-            "code": 1,
-            "description": "Pizzaeria"
-        },
-        {
-            "id": 2,
-            "code": 2,
-            "description": "Risa"
-        }
-    ],
-    "departments": [
-        {
-            "id": 1,
-            "code": "1",
-            "name": "City Tax"
-        }
-    ],
-    "rooms": [
-
-    ]
+  "terminals": [
+    {
+      "id": 1,
+      "number": 1,
+      "description": "Terminal 1",
+      "store_id": 1,
+      "rcrs_number": "1234",
+      "last_invoice_id": 1,
+      "is_locked": false
+    }
+  ],
+  "stores": [
+    {
+      "id": 1,
+      "code": 1,
+      "description": "Pizzaeria"
+    },
+    {
+      "id": 2,
+      "code": 2,
+      "description": "Risa"
+    }
+  ],
+  "departments": [
+    {
+      "code": "1",
+      "name": "City Tax",
+      "payment_type": "debit",
+      "id": 1
+    }
+  ],
+  "rooms": []
 }

--- a/json-mock/db.json
+++ b/json-mock/db.json
@@ -1,13 +1,12 @@
 {
   "terminals": [
     {
-      "id": 1,
       "number": 1,
       "description": "Terminal 1",
-      "store_id": 1,
       "rcrs_number": "1234",
-      "last_invoice_id": 1,
-      "is_locked": false
+      "store_id": 1,
+      "store": 2,
+      "id": 1
     }
   ],
   "stores": [

--- a/projects/crud/src/lib/components/auto-complete-field/auto-complete-field.component.ts
+++ b/projects/crud/src/lib/components/auto-complete-field/auto-complete-field.component.ts
@@ -34,7 +34,6 @@ export class AutoCompleteFieldComponent implements OnChanges {
      }
       this.searchParams = {page: 1};
       this.ctrl = this.form.get(this.field.name) as FormControl;
-      console.log('foreign key value', this.ctrl.value);
       this.filteredOptions = observableOf(this.choices);
       this.filteredOptions = this.ctrl.valueChanges.pipe(
         startWith(''),
@@ -47,7 +46,6 @@ export class AutoCompleteFieldComponent implements OnChanges {
 
    filter(text: string): any[] {
     return this.choices.filter(option => {
-      console.log(text);
       const val = option[this.foreign_model.externalNameField];
       return val ? val.toLowerCase().indexOf(text.toLowerCase()) === 0 : false;
     });

--- a/projects/crud/src/lib/components/foreign-key-field/foreign-key-field.component.html
+++ b/projects/crud/src/lib/components/foreign-key-field/foreign-key-field.component.html
@@ -2,14 +2,14 @@
     <mat-form-field>
         <mat-label>{{ config.label }}</mat-label>
         <button mat-icon-button matPrefix (click)="removeSelection()"><mat-icon [color]="'warn'">delete</mat-icon></button>        
-        <input type="text" matInput [formControlName]="config.name" [matAutocomplete]="auto">
-        <button mat-icon-button matSuffix (click)="openListingDialog()"><mat-icon>search</mat-icon></button>        
-        <!-- <mat-icon matSuffix (click)="openListingDialog()">search</mat-icon> -->
+        <input type="text" matInput [formControl]="_underlyingCtrl" [matAutocomplete]="auto">
     </mat-form-field>
 
     <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn">
-        <mat-option *ngFor="let option of filteredOptions | async" [value]="option[config.control.metadata.externalValueField]">
+        <mat-option *ngFor="let option of availableOptions | async" [value]="option">
             {{ option[config.control.metadata.externalNameField] }}
         </mat-option>
     </mat-autocomplete>
+
+    <button mat-icon-button matSuffix (click)="openListingDialog($event)"><mat-icon>search</mat-icon></button>        
 </div>

--- a/projects/crud/src/lib/components/foreign-key-field/foreign-key-field.component.html
+++ b/projects/crud/src/lib/components/foreign-key-field/foreign-key-field.component.html
@@ -7,7 +7,7 @@
 
     <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn">
         <mat-option *ngFor="let option of availableOptions | async" [value]="option">
-            {{ option[config.control.metadata.externalNameField] }}
+            {{ option[controlConfig.metadata.externalNameField] }}
         </mat-option>
     </mat-autocomplete>
 

--- a/projects/crud/src/lib/components/foreign-key-field/foreign-key-field.component.ts
+++ b/projects/crud/src/lib/components/foreign-key-field/foreign-key-field.component.ts
@@ -105,9 +105,10 @@ export class ForeignKeyFieldComponent implements OnChanges {
         viewConfig: this.controlConfig.viewConfig,
       }
     });
-    ref.afterClosed().subscribe(value => {
-      if (value) {
-        this.formGroup.get(this.config.name).setValue(value);
+    ref.afterClosed().subscribe(result => {
+      if (result.value) {
+        this.availableOptions = of(result.dataSource);
+        this._underlyingCtrl.setValue(result.value);
       }
     });
   }

--- a/projects/crud/src/lib/components/foreign-key-field/foreign-key-field.component.ts
+++ b/projects/crud/src/lib/components/foreign-key-field/foreign-key-field.component.ts
@@ -10,6 +10,7 @@ import { ListingDialogComponent } from '../../containers/listing-dialog/listing-
 
 @Component({
   selector: 'ng-crud-foreign-key-field',
+  exportAs: 'ngcrudui-foreign-key',
   templateUrl: './foreign-key-field.component.html'
 })
 export class ForeignKeyFieldComponent implements OnChanges {

--- a/projects/crud/src/lib/components/foreign-key-field/foreign-key-field.component.ts
+++ b/projects/crud/src/lib/components/foreign-key-field/foreign-key-field.component.ts
@@ -5,7 +5,7 @@ import { map } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 
 import { ApiService } from '../../services/api.service';
-import { FieldConfig, Metadata } from '../../models/metadata';
+import { FieldConfig, ForeignKeyControlConfig } from '../../models/metadata';
 import { ListingDialogComponent } from '../../containers/listing-dialog/listing-dialog.component';
 
 @Component({
@@ -18,6 +18,7 @@ export class ForeignKeyFieldComponent implements OnChanges {
   @Input() forcedSearchParams: any = [];
   @Input() config: FieldConfig;
   @Input() initialChoices: any[];
+  controlConfig: ForeignKeyControlConfig = null;
   availableOptions: Observable<any[]>;
   _underlyingCtrl = new FormControl(null);
 
@@ -29,6 +30,7 @@ export class ForeignKeyFieldComponent implements OnChanges {
     if (!this.formGroup) {
       return;
     }
+    this.controlConfig = this.config.control as ForeignKeyControlConfig;
     const ctrl = this.formGroup.get(this.config.name) as FormControl;
     this._underlyingCtrl.valueChanges.subscribe(res => {
       if ((typeof res) === 'string') {
@@ -36,7 +38,7 @@ export class ForeignKeyFieldComponent implements OnChanges {
           this.availableOptions = of(res);
         });
       } else if (res != null) {
-        this._setControlValue(res[this.config.control.metadata.externalValueField]);
+        this._setControlValue(res[this.controlConfig.metadata.externalValueField]);
       } else {
         this._setControlValue(null);
       }
@@ -52,7 +54,7 @@ export class ForeignKeyFieldComponent implements OnChanges {
   }
 
   fetchById(id: number | string = null) {
-    let url = `${this.config.control.metadata.api}`
+    let url = `${this.controlConfig.metadata.api}`
     if (id != null) {
       url += `/${id}`
     }
@@ -63,7 +65,7 @@ export class ForeignKeyFieldComponent implements OnChanges {
   }
 
   fetch() {
-    let url = `${this.config.control.metadata.api}`
+    let url = `${this.controlConfig.metadata.api}`
     this.api.fetch(url).subscribe(res => {
       this.availableOptions = of(res);
     });
@@ -71,14 +73,14 @@ export class ForeignKeyFieldComponent implements OnChanges {
 
   displayFn(option) {
     if (option == null ) return;
-    return option[this.config.control.metadata.externalNameField];
+    return option[this.controlConfig.metadata.externalNameField];
   }
 
   _filter(value: string): Observable<any[]> {
     const filterValue = value ? value : '';
     const params = {};
-    params[this.config.control.metadata.externalNameField] = filterValue;
-    return this.api.fetch(`${this.config.control.metadata.api}`, params).pipe(
+    params[this.controlConfig.metadata.externalNameField] = filterValue;
+    return this.api.fetch(`${this.controlConfig.metadata.api}`, params).pipe(
       map(res => {
         return res;
       })
@@ -100,7 +102,7 @@ export class ForeignKeyFieldComponent implements OnChanges {
       width: '90%',
       height: '90%',
       data: {
-        viewConfig: this.config.control.viewConfig,
+        viewConfig: this.controlConfig.viewConfig,
       }
     });
     ref.afterClosed().subscribe(value => {

--- a/projects/crud/src/lib/components/form-field/form-field.component.html
+++ b/projects/crud/src/lib/components/form-field/form-field.component.html
@@ -1,6 +1,6 @@
-<div [ngSwitch]="type" class="form-field-wrapper" [formGroup]="formGroup">
+<div [ngSwitch]="config.type" class="form-field-wrapper" [formGroup]="formGroup">
 
-    <div *ngSwitchCase="'switch'">
+    <div *ngSwitchCase="'boolean'">
         <mat-slide-toggle matInput [formControlName]="config.name">{{ config.label }}</mat-slide-toggle>
     </div>
 
@@ -14,7 +14,7 @@
         <mat-label>{{ config.label }}</mat-label>
         <mat-select [formControlName]="config.name">
             <mat-option></mat-option>
-            <mat-option [value]="c.value" *ngFor="let c of choices">
+            <mat-option [value]="c.value" *ngFor="let c of config.control.choices">
                 {{ c.label }}
             </mat-option>
         </mat-select>
@@ -28,17 +28,6 @@
     </mat-form-field>
     
     <ng-container *ngSwitchCase="'foreignKey'">
-        <!-- <mat-form-field>
-            <mat-label>{{ config.label }}</mat-label>
-            <input type="text" matInput [formControlName]="config.name" [matAutocomplete]="auto">
-        </mat-form-field>
-        <button mat-icon-button (click)="openListingDialog()"><mat-icon>search</mat-icon></button>
-        
-        <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn">
-            <mat-option *ngFor="let option of filteredOptions | async" [value]="option[foreign_model.externalValueField]">
-                {{ option[foreign_model.externalNameField] }}
-            </mat-option>
-        </mat-autocomplete> -->
         <ng-crud-foreign-key-field [config]="config" [formGroup]="formGroup"></ng-crud-foreign-key-field>
     </ng-container>
 

--- a/projects/crud/src/lib/components/form-field/form-field.component.html
+++ b/projects/crud/src/lib/components/form-field/form-field.component.html
@@ -4,21 +4,13 @@
         <mat-slide-toggle matInput [formControlName]="config.name">{{ config.label }}</mat-slide-toggle>
     </div>
 
-    <mat-form-field *ngSwitchCase="'textarea'">
-        <mat-label>{{ config.label }}</mat-label>
-        <textarea matInput matTextareaAutosize [formControlName]="config.name"
-            [rows]="config.control.rowSpan || 1"></textarea>
-    </mat-form-field>
+    <ng-container *ngSwitchCase="'textArea'">
+        <ng-crud-text-area-field [formGroup]="formGroup" [config]="config"></ng-crud-text-area-field>
+    </ng-container>
 
-    <mat-form-field *ngSwitchCase="'select'">
-        <mat-label>{{ config.label }}</mat-label>
-        <mat-select [formControlName]="config.name">
-            <mat-option></mat-option>
-            <mat-option [value]="c.value" *ngFor="let c of config.control.choices">
-                {{ c.label }}
-            </mat-option>
-        </mat-select>
-    </mat-form-field>
+    <ng-container *ngSwitchCase="'select'">
+        <ng-crud-select-field [formGroup]="formGroup" [config]="config"></ng-crud-select-field>
+    </ng-container>
 
     <mat-form-field *ngSwitchCase="'date'">
         <mat-label>{{ config.label }}</mat-label>

--- a/projects/crud/src/lib/components/form-field/form-field.component.ts
+++ b/projects/crud/src/lib/components/form-field/form-field.component.ts
@@ -25,83 +25,11 @@ export class FormFieldComponent implements OnChanges {
   type = 'text';
   filteredOptions: Observable<any[]>;
   foreign_model?: Metadata;
-  private modelPath: string[] = [];
 
   constructor(private dialog: MatDialog, private api: ApiService, private reg: Registry) {
-    this.displayFn = this.displayFn.bind(this);
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.config.control && this.config.type === 'foreignKey') {
-      // FOREIGN_MODEL = this.foreign_model;
-      // if (this.choices) {
-      //   this.filteredOptions = of(this.choices);
-      // }
-      // this.api.fetch(`${this.foreign_model.api}`, []).subscribe(res => {
-      //   this.choices = res;
-      //   CHOICES = res;
-      // });
-      this.foreign_model = this.config.control.metadata;
-      const ctrl = this.formGroup.get(this.config.name);
-      this.filteredOptions = ctrl.valueChanges.pipe(
-        startWith(''),
-        debounceTime(200),
-        distinctUntilChanged(),
-        switchMap(val => this._filter(val || null))
-      );
-      // if (this.form.value[this.field.key]) {
-      //   console.log('setting ctrl value', this.form.value[this.field.key]);
-      //   ctrl.setValue(this.form.value[this.field.key]);
-      // }
-    } else if (this.config.control && this.config.type === 'select') {
-      this.choices = this.config.control.choices;
-    }
-
-    this.type = this.config.control && this.config.control.type ? this.config.control.type : 'text';
   }
 
-  getFormControl(field_name: string): FormControl {
-    return this.formGroup.get(field_name) as FormControl;
-  }
-
-  displayFn(option) {
-    for (const c of this.choices) {
-      if (c['id'] === option) {
-        return c[this.foreign_model.externalNameField];
-      }
-    }
-    // return option ? option.code : option;
-  }
-
-  _filter(value: string): Observable<any[]> {
-    if ((typeof value) !== 'string') {
-      return new Observable();
-    }
-    const filterValue = value ? value.toLowerCase() : null;
-    const params = {};
-    params[this.foreign_model.externalNameField] = filterValue;
-    return this.api.fetch(`${this.foreign_model.api}`, params).pipe(
-      map(res => {
-          this.choices = res;
-          return res;
-      })
-    );
-    // return this.choices.filter(option => option.code.toLowerCase().indexOf(filterValue) === 0);
-  }
-
-  openListingDialog() {
-    const ref = this.dialog.open(ListingDialogComponent, {
-      width: '90%',
-      height: '90%',
-      data: {
-        viewConfig: this.config.control.viewConfig,
-        // metadata: this.foreign_model,
-      }
-    });
-    ref.afterClosed().subscribe(value => {
-      if (value) {
-        this.formGroup.get(this.config.name).setValue(value);
-      }
-    });
-  }
 }

--- a/projects/crud/src/lib/components/listing/listing.component.html
+++ b/projects/crud/src/lib/components/listing/listing.component.html
@@ -70,7 +70,7 @@
     </ng-container>
 
     <mat-header-row *matHeaderRowDef="displayColumns"></mat-header-row>
-    <mat-row  *matRowDef="let row; columns: displayColumns;" [ngClass]="{'clickable': mode === 'pick'}" (click)="_picked(row[viewConfig.metadata.externalValueField])"></mat-row>
+    <mat-row  *matRowDef="let row; columns: displayColumns;" [ngClass]="{'clickable': mode === 'pick'}" (click)="_picked(row)"></mat-row>
 </mat-table>
 
 <mat-paginator #paginator *ngIf="viewConfig.pagination.enabled"

--- a/projects/crud/src/lib/components/listing/listing.component.html
+++ b/projects/crud/src/lib/components/listing/listing.component.html
@@ -22,20 +22,21 @@
     </mat-menu>
 </div>
 
-<!-- *ngIf="viewConfig.search.enabled" -->
-<mat-expansion-panel>
-    <mat-expansion-panel-header>
-        <mat-panel-title>
-            <mat-icon>search</mat-icon>
-        </mat-panel-title>
-        <mat-panel-description>
-            Search and filter restults
-        </mat-panel-description>                
-    </mat-expansion-panel-header>
+<ng-template [ngIf]="viewConfig.search.enabled">
+    <mat-expansion-panel>
+        <mat-expansion-panel-header>
+            <mat-panel-title>
+                <mat-icon>search</mat-icon>
+            </mat-panel-title>
+            <mat-panel-description>
+                Search and filter restults
+            </mat-panel-description>                
+        </mat-expansion-panel-header>
 
-    <div #searchComponent></div>
+        <div #searchComponent></div>
 
-</mat-expansion-panel>    
+    </mat-expansion-panel>
+</ng-template>
 
 <mat-progress-bar *ngIf="isLoading" mode="query"></mat-progress-bar>
 

--- a/projects/crud/src/lib/components/listing/listing.component.html
+++ b/projects/crud/src/lib/components/listing/listing.component.html
@@ -22,7 +22,7 @@
     </mat-menu>
 </div>
 
-<ng-template [ngIf]="viewConfig.search.enabled">
+<!-- <ng-template [ngIf]="viewConfig.search.enabled"> -->
     <mat-expansion-panel>
         <mat-expansion-panel-header>
             <mat-panel-title>
@@ -36,7 +36,7 @@
         <div #searchComponent></div>
 
     </mat-expansion-panel>
-</ng-template>
+<!-- </ng-template> -->
 
 <mat-progress-bar *ngIf="isLoading" mode="query"></mat-progress-bar>
 

--- a/projects/crud/src/lib/components/listing/listing.component.ts
+++ b/projects/crud/src/lib/components/listing/listing.component.ts
@@ -34,6 +34,9 @@ export class ListingComponent implements OnInit {
 
     ngOnInit() {
         this.populateDataTable();
+    }
+
+    ngOnChanges() {
         if (this.viewConfig.pagination.enabled) {
             this.searchParams['page'] = 1;
         }

--- a/projects/crud/src/lib/components/listing/listing.component.ts
+++ b/projects/crud/src/lib/components/listing/listing.component.ts
@@ -20,7 +20,6 @@ export class ListingComponent implements OnInit {
     dataSource = new MatTableDataSource();
     searchParams: {page?: number} = {
     };
-    // model: Model;
     columns = [];
     displayColumns: string[] = [];
     resultsCount = 0;
@@ -34,9 +33,6 @@ export class ListingComponent implements OnInit {
 
     ngOnInit() {
         this.populateDataTable();
-    }
-
-    ngOnChanges() {
         if (this.viewConfig.pagination.enabled) {
             this.searchParams['page'] = 1;
         }

--- a/projects/crud/src/lib/components/listing/listing.component.ts
+++ b/projects/crud/src/lib/components/listing/listing.component.ts
@@ -4,6 +4,7 @@ import { MatTableDataSource } from '@angular/material/table';
 
 import { ApiService } from '../../services/api.service';
 import { ListViewer } from '../../models/views';
+import { DataSource } from '@angular/cdk/table';
 
 @Component({
     selector: 'ng-crud-listing',
@@ -131,7 +132,10 @@ export class ListingComponent implements OnInit {
     }
 
     _picked(value) {
-        this.picked.next(value);
+        this.picked.next({
+            'value': value,
+            'dataSource': this.dataSource.data,
+        });
     }
 
 }

--- a/projects/crud/src/lib/components/model-form/model-form.component.html
+++ b/projects/crud/src/lib/components/model-form/model-form.component.html
@@ -4,21 +4,21 @@
 
 <ng-template [ngIf]="is_ready">
     <!-- <div class="form-container"> -->
-    <div class="row" [formGroup]="form">
-        <ng-container *ngFor="let config of controlsConfig">
-            <ng-container *ngIf="config.control && config.control.type === 'fieldset'">
+    <div class="row" [formGroup]="formGroup">
+        <ng-container *ngFor="let config of _visibleControls">
+            <ng-container *ngIf="config.type === 'fieldset'">
                 <div class="fieldset">
                     <h4>{{ config.label }}</h4>
                     <ng-container *ngFor="let config2 of config.fields">
-                        <ng-crud-form-field [formGroup]="form" [config]="config2"></ng-crud-form-field>
+                        <ng-crud-form-field [formGroup]="formGroup" [config]="config2"></ng-crud-form-field>
                     </ng-container>
                 </div>
             </ng-container>
             <!-- <ng-container *ngIf="config.control && config.control.type === 'formset'">
                 <ng-crud-formset [config]="config" [formGroup]="form"></ng-crud-formset>
             </ng-container> -->
-            <ng-container *ngIf="!config.control || (config.control.type !== 'fieldset' && config.control.type !== 'formset')">
-                <ng-crud-form-field [formGroup]="form" [config]="config"></ng-crud-form-field>
+            <ng-container *ngIf="config.type !== 'fieldset' && config.type !== 'formset'">
+                <ng-crud-form-field [formGroup]="formGroup" [config]="config"></ng-crud-form-field>
             </ng-container>
         </ng-container>
     </div>
@@ -26,7 +26,7 @@
 
     <div class="row" *ngFor="let config of viewConfig.formsets; let i=index">
         <mat-divider></mat-divider>
-        <ng-crud-formset [config]="config" [formGroup]="form"></ng-crud-formset>        
+        <ng-crud-formset [config]="config" [formGroup]="formGroup"></ng-crud-formset>        
     </div>
 
     <div class="row">

--- a/projects/crud/src/lib/components/model-form/model-form.component.ts
+++ b/projects/crud/src/lib/components/model-form/model-form.component.ts
@@ -38,16 +38,8 @@ export class ModelFormComponent implements OnInit {
     }
 
     ngOnInit() {
-        // if (this.mode === 'search') {
-        //     console.log(this.viewConfig.controls);
-        //     this.controlsConfig = this.viewConfig.controls.filter(c => c.isSearchable === true);
-        // } else {
-        //     this.controlsConfig = this.viewConfig.controls;
-        // }
         this.controlsConfig = this.viewConfig.controls;
-        this._visibleControls = this.viewConfig.controls;
-        console.log(this.mode, this._visibleControls);
-        // this._visibleControls = this.controlsConfig.filter(c => c.isHidden !== true);
+        this._visibleControls = this.controlsConfig.filter(c => c.isHidden !== true);
         this.formGroup = this.formService.create(this.controlsConfig);
         // attach formsets to the main form group
         this.viewConfig.formsets.forEach(c => {
@@ -82,6 +74,8 @@ export class ModelFormComponent implements OnInit {
                 });
                 this.is_ready = true;
             });
+        } else {
+            this.is_ready = true;
         }
     }
 

--- a/projects/crud/src/lib/components/select-field/select-field.component.ts
+++ b/projects/crud/src/lib/components/select-field/select-field.component.ts
@@ -1,0 +1,38 @@
+import { Component, Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+import { FieldConfig, SelectControlConfig } from '../../models/metadata';
+
+
+@Component({
+  selector: 'ng-crud-select-field',
+  exportAs: 'ngcrudui-select-field',
+  styles: ['.form-field-wrapper{margin-right:  24px}'],
+  template: `
+    <mat-form-field [formGroup]="formGroup">
+        <mat-label>{{ config.label }}</mat-label>
+        <mat-select [formControlName]="config.name">
+            <mat-option></mat-option>
+            <mat-option [value]="c.value" *ngFor="let c of controlConfig.choices">
+                {{ c.label }}
+            </mat-option>
+        </mat-select>
+    </mat-form-field>
+  `
+})
+export class SelectField  {
+
+  @Input() formGroup: FormGroup;
+  @Input() config: FieldConfig;
+  controlConfig: SelectControlConfig;
+
+  constructor() {
+
+  }
+
+  ngOnInit() {
+      this.controlConfig = this.config.control as SelectControlConfig;
+  }
+
+
+}

--- a/projects/crud/src/lib/components/text-area-field/text-area-field.component.ts
+++ b/projects/crud/src/lib/components/text-area-field/text-area-field.component.ts
@@ -1,0 +1,33 @@
+import { Component, Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+import { FieldConfig, TextAreaControlConfig } from '../../models/metadata';
+
+
+@Component({
+  selector: 'ng-crud-text-area-field',
+  exportAs: 'ngcrudui-text-area-field',
+  styles: ['.form-field-wrapper{margin-right:  24px}'],
+  template: `<mat-form-field [formGroup]="formGroup">
+      <mat-label>{{ config.label }}</mat-label>
+      <textarea matInput matTextareaAutosize [formControlName]="config.name"
+      [rows]="controlConfig?.rowSpan || 1"></textarea>
+    </mat-form-field>
+  `
+})
+export class TextAreaField  {
+
+  @Input() formGroup: FormGroup;
+  @Input() config: FieldConfig;
+  controlConfig: TextAreaControlConfig;
+
+  constructor() {
+
+  }
+
+  ngOnInit() {
+      this.controlConfig = this.config.control as TextAreaControlConfig;
+  }
+
+
+}

--- a/projects/crud/src/lib/containers/listing-dialog/listing-dialog.component.ts
+++ b/projects/crud/src/lib/containers/listing-dialog/listing-dialog.component.ts
@@ -1,10 +1,7 @@
 import { Component, OnInit, Inject, ComponentFactoryResolver, ViewContainerRef, ViewChild } from '@angular/core';
-import { ActivatedRoute , Router} from '@angular/router';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 
-import { Registry } from '../../services/registry.service';
 import { Metadata } from '../../models/metadata';
-import { ListingView, ListViewer } from '../../models/views';
 
 @Component({
   templateUrl: 'listing-dialog.component.html',
@@ -16,7 +13,6 @@ export class ListingDialogComponent implements OnInit {
     @ViewChild('listingView', {read: ViewContainerRef}) listingView: ViewContainerRef;
 
     constructor(
-      private reg: Registry,
       private ref: MatDialogRef<ListingDialogComponent>,
       private container: ViewContainerRef,
       private resolver: ComponentFactoryResolver,
@@ -38,6 +34,7 @@ export class ListingDialogComponent implements OnInit {
     }
 
     picked(value) {
+      console.log('value picked', value)
       this.ref.close(value);
     }
 

--- a/projects/crud/src/lib/crud.module.ts
+++ b/projects/crud/src/lib/crud.module.ts
@@ -37,6 +37,8 @@ import { FormFieldComponent } from './components/form-field/form-field.component
 import { FormsetComponent } from './components/formset/formset.component';
 import { AutoCompleteFieldComponent } from './components/auto-complete-field/auto-complete-field.component';
 import { ForeignKeyFieldComponent } from './components/foreign-key-field/foreign-key-field.component';
+import { TextAreaField } from './components/text-area-field/text-area-field.component';
+import { SelectField } from './components/select-field/select-field.component';
 
 import { ScreenWrapperComponent } from './containers/screen-wrapper/screen-wrapper.component';
 import { ListingDialogComponent } from './containers/listing-dialog/listing-dialog.component';
@@ -82,6 +84,8 @@ import { ListingDialogComponent } from './containers/listing-dialog/listing-dial
     FormsetComponent,
     ForeignKeyFieldComponent,
     ListingDialogComponent,
+    TextAreaField,
+    SelectField,
   ],
   providers: [
   ],
@@ -116,6 +120,8 @@ import { ListingDialogComponent } from './containers/listing-dialog/listing-dial
     ScreenWrapperComponent,
     FormsetComponent,
     ForeignKeyFieldComponent,
+    TextAreaField,
+    SelectField,
   ],
   entryComponents: [
     ListingComponent,

--- a/projects/crud/src/lib/models/metadata.ts
+++ b/projects/crud/src/lib/models/metadata.ts
@@ -2,11 +2,9 @@ import { ViewConfig } from './views';
 
 export interface ControlConfig {
     type?: string;
-    // type: 'input' | 'number' | 'select' | 'date' | 'datetime' | 'foreignKey';
     metadata?: any;
     multiple?: boolean;
     autocomplete?: {
-        enabled: boolean,
         api?: string;
         valueField: string,
         labelFields: string[],
@@ -20,9 +18,10 @@ export interface ControlConfig {
 export class FieldConfig {
     name: string;
     label: string;
-    type?: string;
+    type?: 'text' | 'number' | 'boolean' | 'select' | 'date' | 'datetime' | 'foreignKey' | 'formset' | 'fieldset' = 'text';
     isEditable?: boolean = true;
     isSearchable?: boolean = true;
+    isHidden? = false;
     control?: ControlConfig;
     validators?: any[];
     foreignModelPath?: string;
@@ -30,6 +29,8 @@ export class FieldConfig {
     choices?: any[];
     // if fieldset
     fields?: FieldConfig[];
+    // if foreignKey
+    resolveValueFrom?: string;
 }
 
 export interface Fieldset extends FieldConfig {

--- a/projects/crud/src/lib/models/metadata.ts
+++ b/projects/crud/src/lib/models/metadata.ts
@@ -2,27 +2,46 @@ import { ViewConfig } from './views';
 
 export interface ControlConfig {
     type?: string;
-    metadata?: any;
+}
+
+export interface FieldSetControlConfig extends ControlConfig {
+    fields: FieldConfig[];
+}
+
+export interface FormSetControlConfig extends ControlConfig {
+    fields: FieldConfig[];
+}
+
+export interface ForeignKeyControlConfig extends ControlConfig {
+    metadata: Metadata;
+    viewConfig?: ViewConfig;
+}
+
+export interface SelectControlConfig extends ControlConfig {
     multiple?: boolean;
-    autocomplete?: {
+    choices: {[key: string]: any}[];
+}
+
+export interface AutoCompleteControlConfig extends SelectControlConfig {
+    autocomplete: {
         api?: string;
         valueField: string,
         labelFields: string[],
     };
+}
+
+export interface TextAreaControlConfig extends ControlConfig {
     rowSpan?: Number;
-    choices?: {[key: string]: any}[]; // for select controls
-    viewConfig?: ViewConfig;
-    fields?: FieldConfig[];
 }
 
 export class FieldConfig {
     name: string;
     label: string;
-    type?: 'text' | 'number' | 'boolean' | 'select' | 'date' | 'datetime' | 'foreignKey' | 'formset' | 'fieldset' = 'text';
+    type?: 'text' | 'number' | 'boolean' | 'textArea' | 'select' | 'date' | 'datetime' | 'foreignKey' | 'formset' | 'fieldset' = 'text';
     isEditable?: boolean = true;
     isSearchable?: boolean = true;
     isHidden? = false;
-    control?: ControlConfig;
+    control?: ControlConfig | ForeignKeyControlConfig | TextAreaControlConfig | SelectControlConfig | AutoCompleteControlConfig | FormSetControlConfig | FieldSetControlConfig;
     validators?: any[];
     foreignModelPath?: string;
     valueType?: string;

--- a/projects/crud/src/lib/models/views.ts
+++ b/projects/crud/src/lib/models/views.ts
@@ -54,7 +54,6 @@ export class FormView implements FormViewer {
     formsets = this.metadata.formsets;
 
     constructor(public metadata: Metadata) {
-        // const fields: FieldConfig[] = [];
         metadata.fields.filter(f => f.isEditable !== false).forEach(field => {
             this.controls.push(field as FieldConfig);
         });

--- a/projects/crud/src/lib/models/views.ts
+++ b/projects/crud/src/lib/models/views.ts
@@ -11,7 +11,7 @@ export interface ViewConfig {
 }
 
 export interface ListViewer extends ViewConfig {
-    search?: {
+    search: {
         enabled: boolean,
         view: FormViewer
     };
@@ -29,7 +29,6 @@ export interface FormViewer extends ViewConfig {
 }
 
 export class ListingView implements ListViewer {
-
     title = this.metadata.label;
     breadcrumbs = [];
     component = ListingComponent;

--- a/projects/crud/src/lib/services/form.service.ts
+++ b/projects/crud/src/lib/services/form.service.ts
@@ -2,7 +2,7 @@ import { Injectable, EventEmitter } from '@angular/core';
 import { AbstractControl, FormGroup, FormControl, FormArray } from '@angular/forms';
 import { Observable ,  Subject } from 'rxjs';
 import { Field  } from '../forms';
-import { FieldConfig, Fieldset, FormsetConfig } from '../models/metadata';
+import { FieldConfig, Fieldset, FormsetConfig, FormSetControlConfig } from '../models/metadata';
 
 @Injectable({
   providedIn: 'root'
@@ -56,7 +56,8 @@ export class FormService {
         });
         return;
       } else if (c.type === 'formset') {
-        const group = this.create(c.control.fields);
+        const controlConfig = c.control as FormSetControlConfig;
+        const group = this.create(controlConfig.fields);
         ctrls[c.name] = new FormArray([group]);
         return;
       }

--- a/projects/crud/src/lib/services/form.service.ts
+++ b/projects/crud/src/lib/services/form.service.ts
@@ -50,12 +50,12 @@ export class FormService {
   create(config: FieldConfig[]): FormGroup {
     const ctrls = {};
     config.forEach(c => {
-      if (c.control && c.control.type === 'fieldset') {
+      if (c.type === 'fieldset') {
         (c as Fieldset).fields.forEach(innerC => {
           ctrls[innerC.name] = new FormControl(null, c.validators);
         });
         return;
-      } else if (c.control && c.control.type === 'formset') {
+      } else if (c.type === 'formset') {
         const group = this.create(c.control.fields);
         ctrls[c.name] = new FormArray([group]);
         return;

--- a/projects/crud/src/public_api.ts
+++ b/projects/crud/src/public_api.ts
@@ -4,12 +4,16 @@
 
 export * from './lib/models/metadata';
 export * from './lib/models/views';
+
 export * from './lib/components/auto-complete-field/auto-complete-field.component';
 export * from './lib/components/foreign-key-field/foreign-key-field.component';
 export * from './lib/components/form-field/form-field.component';
 export * from './lib/components/formset/formset.component';
 export * from './lib/components/listing/listing.component';
 export * from './lib/components/model-form/model-form.component';
+export * from './lib/components/select-field/select-field.component';
+export * from './lib/components/text-area-field/text-area-field.component';
+
 export * from './lib/containers/listing-dialog/listing-dialog.component';
 export * from './lib/containers/screen-wrapper/screen-wrapper.component';
 export * from './lib/services/registry.service';

--- a/projects/docs/src/assets/docs/foreignKeys.md
+++ b/projects/docs/src/assets/docs/foreignKeys.md
@@ -1,3 +1,61 @@
 # Foreign Keys
 
-not ready yet
+You can use the ForeginKeyField component to create a field that automatically knows 
+how to pull information of the given metadata of the foreign key.
+
+You can use it inside your templates like this:
+
+```html
+<ngcrudui-foreign-key [formGroup]="formGroup" [config]="fieldConfig" ></ngcrudui-foreign-key>
+```
+
+There are more configuration that you can pass to it,
+let's talk more about that:
+
+The configuration should implement the `FieldConfig` interface with the `control` field to implement the 
+`ForeignKeyControlConfig` interface:
+
+```typescript
+export interface ForeignKeyControlConfig extends ControlConfig {
+    metadata: Metadata;
+    viewConfig?: ViewConfig;
+}
+```
+
+so let's take alook on an example for defining a ForeignKey Field:
+
+```typescript
+{
+    name: 'store',
+    label: 'Outlet',
+    type: 'foreignKey',
+    resolveValueFrom: 'store_id',
+    control: {
+        metadata: new StoreMetadata(),
+        viewConfig: new StoreListView(),
+    }
+}
+```
+
+As you cane see there is a `resolveValueFrom` that would tell NgCrudUi to get/set the value to another field -if you need to, and in the case there has to be a definition for another field, the `store_id` field, but we don't want it to be displayed in the forms, so we can set `isHidden` to true, here is the full example:
+
+```typescript
+{
+    name: 'store_id',
+    label: 'Outlet ID',
+    type: 'number',
+    isHidden: true,
+},
+{
+    name: 'store',
+    label: 'Outlet',
+    type: 'foreignKey',
+    resolveValueFrom: 'store_id',
+    control: {
+        metadata: new StoreMetadata(),
+        viewConfig: new StoreListView(),
+    },
+    isEditable: true,
+    isSearchable: true,
+}
+```

--- a/projects/example-app/src/app/app.component.ts
+++ b/projects/example-app/src/app/app.component.ts
@@ -40,15 +40,14 @@ export class AppComponent implements OnInit {
 
   registerViews() {
     const terminalListing = new ListingView(new TerminalMetadata());
-    terminalListing.pagination.enabled = false;
+    terminalListing.search.enabled = true;
     terminalListing.search.view = new TerminalSearchForm(new TerminalMetadata());
+    terminalListing.pagination.enabled = false;
     this.reg.registerScreen('pos/terminals', terminalListing);
     const terminalForm = new FormView(new TerminalMetadata());
-    // this.reg.registerScreen('pos/terminals/new', terminalForm);
     this.reg.registerScreen('pos/terminals/:id', terminalForm);
     //
     this.reg.registerScreen('inventory/stores', new StoreListView());
-    // this.reg.registerScreen('inventory/stores/new', new FormView(new StoreMetadata()));
     this.reg.registerScreen('inventory/stores/:id', new FormView(new StoreMetadata()))
     //
     const departmentListing = new ListingView(new DepartmentMetadata());
@@ -58,9 +57,10 @@ export class AppComponent implements OnInit {
     // rooms
     const roomListing = new ListingView(new RoomMetadata());
     roomListing.pagination.enabled = false;
+    roomListing.search.enabled = false;
     this.reg.registerScreen('pms/rooms', roomListing);
-    // const roomForm = new FormView(new RoomFo());
-    this.reg.registerScreen('pms/rooms/:id', new RoomForm(new RoomMetadata()));
+    const roomForm = new RoomForm(new RoomMetadata());
+    this.reg.registerScreen('pms/rooms/:id', roomForm);
   }
 
 }

--- a/projects/example-app/src/app/app.component.ts
+++ b/projects/example-app/src/app/app.component.ts
@@ -41,7 +41,7 @@ export class AppComponent implements OnInit {
   registerViews() {
     const terminalListing = new ListingView(new TerminalMetadata());
     terminalListing.pagination.enabled = false;
-    terminalListing.search.view = new TerminalSearchForm(new TerminalMetadata());
+    // terminalListing.search.view = new TerminalSearchForm(new TerminalMetadata());
     this.reg.registerScreen('pos/terminals', terminalListing);
     const terminalForm = new FormView(new TerminalMetadata());
     // this.reg.registerScreen('pos/terminals/new', terminalForm);

--- a/projects/example-app/src/app/app.component.ts
+++ b/projects/example-app/src/app/app.component.ts
@@ -40,14 +40,15 @@ export class AppComponent implements OnInit {
 
   registerViews() {
     const terminalListing = new ListingView(new TerminalMetadata());
-    terminalListing.search.enabled = true;
-    terminalListing.search.view = new TerminalSearchForm(new TerminalMetadata());
     terminalListing.pagination.enabled = false;
+    terminalListing.search.view = new TerminalSearchForm(new TerminalMetadata());
     this.reg.registerScreen('pos/terminals', terminalListing);
     const terminalForm = new FormView(new TerminalMetadata());
+    // this.reg.registerScreen('pos/terminals/new', terminalForm);
     this.reg.registerScreen('pos/terminals/:id', terminalForm);
     //
     this.reg.registerScreen('inventory/stores', new StoreListView());
+    // this.reg.registerScreen('inventory/stores/new', new FormView(new StoreMetadata()));
     this.reg.registerScreen('inventory/stores/:id', new FormView(new StoreMetadata()))
     //
     const departmentListing = new ListingView(new DepartmentMetadata());
@@ -57,10 +58,9 @@ export class AppComponent implements OnInit {
     // rooms
     const roomListing = new ListingView(new RoomMetadata());
     roomListing.pagination.enabled = false;
-    roomListing.search.enabled = false;
     this.reg.registerScreen('pms/rooms', roomListing);
-    const roomForm = new RoomForm(new RoomMetadata());
-    this.reg.registerScreen('pms/rooms/:id', roomForm);
+    // const roomForm = new FormView(new RoomFo());
+    this.reg.registerScreen('pms/rooms/:id', new RoomForm(new RoomMetadata()));
   }
 
 }

--- a/projects/example-app/src/app/forms/room.edit.form.ts
+++ b/projects/example-app/src/app/forms/room.edit.form.ts
@@ -1,6 +1,7 @@
-import { FormView } from 'crud';
+import { FormView, FormsetConfig } from 'crud';
 
 export class RoomForm extends FormView {
+    label = 'Rooms';
     layout = 'horizontal';
     controls = [
         {
@@ -12,7 +13,7 @@ export class RoomForm extends FormView {
             label: 'Type'
         }
     ];
-    formsets = [
+    formsets: FormsetConfig[] = [
         {
             name: 'occupancy',
             label: 'Occupancy',
@@ -20,16 +21,12 @@ export class RoomForm extends FormView {
                 {
                     name: 'number_of_adults',
                     label: 'Adults',
-                    control: {
-                        type: 'number'
-                    }
+                    type: 'number'
                 },
                 {
                     name: 'number_of_children',
                     label: 'Children',
-                    control: {
-                        type: 'number'
-                    }
+                    type: 'number'
                 }
             ]
         }

--- a/projects/example-app/src/app/forms/room.edit.form.ts
+++ b/projects/example-app/src/app/forms/room.edit.form.ts
@@ -1,9 +1,9 @@
-import { FormView, FormsetConfig } from 'crud';
+import { FormView, FormsetConfig, FieldConfig } from 'crud';
 
 export class RoomForm extends FormView {
     label = 'Rooms';
     layout = 'horizontal';
-    controls = [
+    controls: FieldConfig[] = [
         {
             name: 'number',
             label: 'Number'
@@ -11,6 +11,11 @@ export class RoomForm extends FormView {
         {
             name: 'type',
             label: 'Type'
+        },
+        {
+            name: 'description',
+            label: 'Description',
+            type: 'textArea'
         }
     ];
     formsets: FormsetConfig[] = [

--- a/projects/example-app/src/app/forms/store.search.form.ts
+++ b/projects/example-app/src/app/forms/store.search.form.ts
@@ -1,8 +1,8 @@
-import { FormView } from 'crud';
+import { FormView, FieldConfig } from 'crud';
 
 export class StoreSearchForm extends FormView {
     layout = 'horizontal';
-    controls = [
+    controls: FieldConfig[] = [
         {
             name: 'code',
             label: 'Code'
@@ -14,17 +14,17 @@ export class StoreSearchForm extends FormView {
         {
             name: 'fieldset1',
             label: 'Fieldset',
+            type: 'fieldset',
             control: {
-                type: 'fieldset',
-            },
-            fields: [{
-                name: 'show_paymaster',
-                label: 'Show Paymaster',
-                type: 'boolean',
-                control: {
-                    type: 'switch'
-                }
-            }]
+                fields: [{
+                    name: 'show_paymaster',
+                    label: 'Show Paymaster',
+                    type: 'boolean',
+                    control: {
+                        type: 'switch'
+                    }
+                }]
+            }
         }
     ];
 }

--- a/projects/example-app/src/app/forms/terminal.search.form.ts
+++ b/projects/example-app/src/app/forms/terminal.search.form.ts
@@ -1,10 +1,11 @@
-import { FormView } from 'crud';
+import { FormView, FieldConfig } from 'crud';
 import { StoreListView } from '../views/store.list.view';
 import { StoreMetadata } from '../metadata/store.metadata';
 
 export class TerminalSearchForm extends FormView {
+    title = 'Search Teminals';
     layout = 'horizontal';
-    controls = [
+    controls: FieldConfig[] = [
         {
             name: 'number',
             label: 'Number',
@@ -18,11 +19,10 @@ export class TerminalSearchForm extends FormView {
         {
             name: 'rcrs_number',
             label: 'RCRS',
-            type: 'string',
+            type: 'select',
             control: {
-                type: 'select',
+                type: 'autocomplete',
                 autocomplete: {
-                    enabled: true,
                     api: '/api/pos/rcrs/',
                     valueField: 'id',
                     labelFields: ['description']
@@ -33,11 +33,12 @@ export class TerminalSearchForm extends FormView {
         {
             name: 'store',
             label: 'Outlet',
+            type: 'foreignKey',
             control: {
-                type: 'foreignKey',
                 metadata: new StoreMetadata(),
                 viewConfig: new StoreListView(),
             }
         }
     ];
+
 }

--- a/projects/example-app/src/app/metadata/department.metadata.ts
+++ b/projects/example-app/src/app/metadata/department.metadata.ts
@@ -1,5 +1,4 @@
-import { Validators } from '@angular/forms';
-import { Metadata } from 'crud';
+import { Metadata, FieldConfig } from 'crud';
 import { Department } from '../models/department.model';
 
 export class DepartmentMetadata implements Metadata {
@@ -10,11 +9,11 @@ export class DepartmentMetadata implements Metadata {
     listingFields = ['id', 'code', 'name'];
     externalNameField = 'name';
     externalValueField = 'id';
-    fields = [
+    fields: FieldConfig[] = [
         {
             name: 'id',
             label: 'ID',
-            type: 'id',
+            type: 'number',
             isEditable: false,
         },
         {
@@ -25,12 +24,13 @@ export class DepartmentMetadata implements Metadata {
         {
             name: 'name',
             label: 'Name',
+            type: 'text'
         },
         {
             name: 'payment_type',
             label: 'Payment Type',
+            type: 'select',
             control: {
-                type: 'select',
                 choices: [{label: 'Debit', value: 'debit'}, {label: 'Credit', value: 'credit'}]
             }
         }

--- a/projects/example-app/src/app/metadata/department.metadata.ts
+++ b/projects/example-app/src/app/metadata/department.metadata.ts
@@ -6,7 +6,7 @@ export class DepartmentMetadata implements Metadata {
     label = 'Department';
     api = '/api/departments';
     model = Department;
-    listingFields = ['id', 'code', 'name'];
+    listingFields = ['id', 'code', 'name', 'payment_type'];
     externalNameField = 'name';
     externalValueField = 'id';
     fields: FieldConfig[] = [

--- a/projects/example-app/src/app/metadata/room.metadata.ts
+++ b/projects/example-app/src/app/metadata/room.metadata.ts
@@ -1,9 +1,5 @@
-import { Validators } from '@angular/forms';
-import { HttpClient } from '@angular/common/http';
-import { Metadata } from 'crud';
+import { Metadata, FieldConfig } from 'crud';
 import { Room } from '../models/room.model';
-import { StoreMetadata } from '../metadata/store.metadata';
-import { StoreListView } from '../views/store.list.view';
 
 export class RoomMetadata implements Metadata {
     name = 'room';
@@ -13,11 +9,11 @@ export class RoomMetadata implements Metadata {
     listingFields = ['id', 'number', 'type'];
     externalNameField = 'type';
     externalValueField = 'id';
-    fields = [
+    fields: FieldConfig[] = [
         {
             name: 'id',
             label: 'ID',
-            type: 'id',
+            type: 'number',
             isSearchable: true,
         },
         {
@@ -30,6 +26,7 @@ export class RoomMetadata implements Metadata {
         {
             name: 'type',
             label: 'Type',
+            type: 'text',
             isEditable: true,
             isSearchable: true,
         }

--- a/projects/example-app/src/app/metadata/room.metadata.ts
+++ b/projects/example-app/src/app/metadata/room.metadata.ts
@@ -6,7 +6,7 @@ export class RoomMetadata implements Metadata {
     label = 'Room';
     api = '/api/rooms';
     model = Room;
-    listingFields = ['id', 'number', 'type'];
+    listingFields = ['id', 'number', 'type', 'description'];
     externalNameField = 'type';
     externalValueField = 'id';
     fields: FieldConfig[] = [
@@ -29,6 +29,11 @@ export class RoomMetadata implements Metadata {
             type: 'text',
             isEditable: true,
             isSearchable: true,
+        },
+        {
+            name: 'description',
+            label: 'Description',
+            type: 'textArea',
         }
     ];
     formsets = [];

--- a/projects/example-app/src/app/metadata/store.metadata.ts
+++ b/projects/example-app/src/app/metadata/store.metadata.ts
@@ -26,10 +26,7 @@ export class StoreMetadata implements Metadata {
         {
             name: 'description',
             label: 'Description',
-            type: 'textArea',
-            control: {
-                rowSpan: 5,
-            }
+            type: 'text',
         },
         {
             name: 'show_paymaster',

--- a/projects/example-app/src/app/metadata/store.metadata.ts
+++ b/projects/example-app/src/app/metadata/store.metadata.ts
@@ -1,4 +1,3 @@
-import { Validators } from '@angular/forms';
 import { Store } from '../models/store.model';
 import { Metadata, FieldConfig } from 'crud';
 
@@ -27,7 +26,10 @@ export class StoreMetadata implements Metadata {
         {
             name: 'description',
             label: 'Description',
-            type: 'text'
+            type: 'textArea',
+            control: {
+                rowSpan: 5,
+            }
         },
         {
             name: 'show_paymaster',

--- a/projects/example-app/src/app/metadata/terminal.metadata.ts
+++ b/projects/example-app/src/app/metadata/terminal.metadata.ts
@@ -1,6 +1,6 @@
 import { Validators } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
-import { Metadata } from 'crud';
+import { Metadata, FieldConfig } from 'crud';
 import { Terminal } from '../models/terminal.model';
 import { StoreMetadata } from '../metadata/store.metadata';
 import { StoreListView } from '../views/store.list.view';
@@ -10,16 +10,16 @@ export class TerminalMetadata implements Metadata {
     label = 'Terminal';
     api = '/api/terminals';
     model = Terminal;
-    listingFields = ['id', 'number', 'description', 'rcrs_number', 'last_invoice_id', 'is_locked'];
+    listingFields = ['id', 'number', 'description', 'rcrs_number', 'last_invoice_id', 'is_locked', 'store'];
     externalNameField = 'description';
     externalValueField = 'id';
     formsets = [];
-    fields = [
+    fields: FieldConfig[] = [
         {
             name: 'id',
             label: 'ID',
             type: 'number',
-            isSearchable: true,
+            isEditable: false,
         },
         {
             name: 'number',
@@ -38,7 +38,7 @@ export class TerminalMetadata implements Metadata {
         {
             name: 'rcrs_number',
             label: 'RCRS',
-            type: 'string',
+            type: 'text',
             validators: [
                 Validators.required,
                 Validators.maxLength(11),
@@ -60,9 +60,16 @@ export class TerminalMetadata implements Metadata {
             isEditable: false,
         },
         {
+            name: 'store_id',
+            label: 'Outlet ID',
+            type: 'number',
+            isHidden: true,
+        },
+        {
             name: 'store',
             label: 'Outlet',
             type: 'foreignKey',
+            resolveValueFrom: 'store_id',
             control: {
                 metadata: new StoreMetadata(),
                 viewConfig: new StoreListView(),


### PR DESCRIPTION
- [x] Fix evaluation for field value
- [x] Provide configuration to evaluate/publish value to another field, for example field 'Outlet' evaluates value from 'store_id' field, and 'store_id' field is hidden, doesn't appear in the form, it's value needed implicitly.
- [x] Fix overlapping of the foreign key popup and dropdown menu
- [x] Write documentation for using and configuring ForeginKey fields