### PR TITLE
Cap attachment upload concurrency at 2

### DIFF
--- a/projects/crud/src/lib/services/api.service.spec.ts
+++ b/projects/crud/src/lib/services/api.service.spec.ts
@@ -1,0 +1,75 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController, TestRequest } from '@angular/common/http/testing';
+
+import { ApiService } from './api.service';
+import { AttachmentsService } from './attachments.service';
+
+describe('ApiService attachment uploads', () => {
+    const api = '/api/core/individualprofile/v3/34120/attachments';
+
+    let service: ApiService;
+    let attachmentsService: AttachmentsService;
+    let httpTestingController: HttpTestingController;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [ApiService, AttachmentsService],
+        });
+
+        httpTestingController = TestBed.inject(HttpTestingController);
+        service = TestBed.inject(ApiService);
+        attachmentsService = TestBed.inject(AttachmentsService);
+    });
+
+    afterEach(() => {
+        httpTestingController.verify();
+    });
+
+    function queueFiles(count: number) {
+        attachmentsService.attachmentsFormData = Array.from(
+            { length: count },
+            (value, index) => new File(['content'], `file-${index}.txt`)
+        );
+    }
+
+    function openRequests(): TestRequest[] {
+        return httpTestingController.match(api);
+    }
+
+    it('never keeps more than two uploads in flight', () => {
+        queueFiles(5);
+        service.post(api, {}, 'attachments').subscribe();
+
+        const firstWindow = openRequests();
+        expect(firstWindow.length).toBe(2);
+        firstWindow.forEach(request => request.flush({}));
+
+        const secondWindow = openRequests();
+        expect(secondWindow.length).toBe(2);
+        secondWindow.forEach(request => request.flush({}));
+
+        const thirdWindow = openRequests();
+        expect(thirdWindow.length).toBe(1);
+        thirdWindow.forEach(request => request.flush({}));
+    });
+
+    it('posts every queued file exactly once', () => {
+        queueFiles(5);
+        const uploaded = [];
+        service.post(api, {}, 'attachments').subscribe();
+
+        let window = openRequests();
+        while (window.length) {
+            window.forEach(request => {
+                uploaded.push((request.request.body as FormData).get('file')['name']);
+                request.flush({});
+            });
+            window = openRequests();
+        }
+
+        expect(uploaded.sort()).toEqual([
+            'file-0.txt', 'file-1.txt', 'file-2.txt', 'file-3.txt', 'file-4.txt',
+        ]);
+    });
+});

--- a/projects/crud/src/lib/services/api.service.ts
+++ b/projects/crud/src/lib/services/api.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable, of, forkJoin, throwError } from 'rxjs';
-import { catchError, tap } from 'rxjs/operators';
+import { Observable, of, forkJoin, from, throwError } from 'rxjs';
+import { catchError, mergeMap, tap, toArray } from 'rxjs/operators';
 import { AttachmentsService } from './attachments.service';
 
+// Uploading every selected file at once occupies one server request slot per file.
+const MAX_CONCURRENT_UPLOADS = 2;
 
 @Injectable({
     providedIn: 'root'
@@ -63,7 +65,10 @@ export class ApiService {
                             catchError(error => throwError(error))
                         ));
                 });
-                return forkJoin(responses);
+                return from(responses).pipe(
+                    mergeMap(upload => upload, MAX_CONCURRENT_UPLOADS),
+                    toArray()
+                );
             } else {
                 return of(null)
             }


### PR DESCRIPTION
`ApiService.post()` builds an array of cold `HttpClient` POSTs when `fieldName === 'attachments'` and hands it to `forkJoin`, which subscribes to all of them simultaneously. There is no cap, so the number of parallel uploads equals however many files the user picked.

**Change.** `from(uploads).pipe(mergeMap(o => o, 2), toArray())` - at most 2 uploads in flight, the next starting as each completes. The caller (`model-form.component.ts:473`) discards the result array, so completion-order results are safe. The bulk-delete `forkJoin` in the same file is untouched - deletes carry no request body.

**Regression test.** `projects/crud/src/lib/services/api.service.spec.ts` - `never keeps more than two uploads in flight` fails on the unfixed code with `Expected 5 to be 2`, passes after (2/2 SUCCESS).

Note for reviewers: `ng test crud` and `ng build crud` are both already broken on `master` for unrelated reasons (`@ngxs/store` and `core-js` not installed, `attachments.service.gen.spec.ts` references members `AttachmentsService` no longer has, and NGC template type-check throws `Cannot read property 'type' of null`). Verified by stashing this diff and re-running on a clean `master` - identical failures. The new spec was run against a temporarily scoped `test.ts` / `tsconfig.spec.json`, both reverted before committing.

This ships as an npm package, so it needs a version bump + publish before the fix reaches consumers.